### PR TITLE
Specify SW API version with default to v3

### DIFF
--- a/ShipwireConnector.php
+++ b/ShipwireConnector.php
@@ -42,7 +42,7 @@ class ShipwireConnector
     /**
      * @var string
      */
-    static $version = 'v3.1';
+    static $version = 'v3';
 
     /**
      * @var HandlerStack
@@ -129,7 +129,7 @@ class ShipwireConnector
      * @throws ShipwireConnectionException
      * @throws \Exception
      */
-    public function api($resource, $params = [], $method = "GET", $body = null, $onlyResource = false, $returnDespiteError = false)
+    public function api($resource, $params = [], $method = "GET", $body = null, $onlyResource = false, $returnDespiteError = false, $version = null)
     {
         $client = self::getClient();
 
@@ -144,7 +144,7 @@ class ShipwireConnector
                 $headers['content-type'] = 'application/json';
             }
 
-            $version = self::$version;
+            $version = $version ?? self::$version;
             $response = $client->request($method, "/api/{$version}/".$resource, [
                 'headers' => $headers,
                 'query' => $params,


### PR DESCRIPTION
Reverted the static $version from v3.1 to v3. This is the default API version to use.

Added a new argument to the api() method to allow for the passing of a $version. The default value is null.

If no value is passed, the version is set to self::$version which is v3. To use Shipwire API address verification we just need to append the version, so the call to api() would look like this:

$this->_connector->api('addressValidation', [], ShipwireConnector::POST, json_encode($requestData), false, true, 'v3.1')